### PR TITLE
[Feature] Station realtime PIDS; train compilation history from com.wifi12306

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ After downloading the project, please run:
     │   └── train_wifi12306.py - query train info from `com.wifi12306`
     ├── railroad_lib        - Some helper libraries taken from other projs
     │   ├── __init__.py
+    │   ├── pids_realtime.py   - By AgFlore, for querying station's real-time PIDS board from `com.wifi12306`
     │   ├── query12306.py   - By Lifan Zhang, for timetable function
     │   ├── query_wifi12306.py   - By AgFlore, for querying information from `com.wifi12306`
     │   ├── train_history.py - helper file for train no.
     │   └── TrainNoDB.py    - a searchable db of train numbers. Saved for future functionalities.
-    └── requirements.txt    - python packages required 
+    └── requirements.txt    - python packages required
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ After downloading the project, please run:
     │   ├── basics.py       - Basic welcome module.
     │   ├── history.py      - query the history of the train. (for Shanghai and Beijing Railway EMUs.)
     │   ├── timetable.py    - timetable lookup module.
-    │   └── train_plan_graph.py - get the planning graph of the train no. using moerail.ml functionality.
+    │   ├── train_plan_graph.py - get the planning graph of the train no. using moerail.ml functionality.
+    │   └── train_wifi12306.py - query train info from `com.wifi12306`
     ├── railroad_lib        - Some helper libraries taken from other projs
     │   ├── __init__.py
     │   ├── query12306.py   - By Lifan Zhang, for timetable function
+    │   ├── query_wifi12306.py   - By AgFlore, for querying information from `com.wifi12306`
     │   ├── train_history.py - helper file for train no.
     │   └── TrainNoDB.py    - a searchable db of train numbers. Saved for future functionalities.
     └── requirements.txt    - python packages required 

--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -2,12 +2,14 @@
 # init.py for the commands folder
 # By waymao in 2019
 
-from . import basics, timetable, train_plan_graph, history
+from . import basics, timetable, train_plan_graph, history, train_wifi12306
 
 handlers = [
     basics.start_handler,
     timetable.timetable_handler,
     train_plan_graph.graph_handler,
     history.train_info_handler,
-    history.train_no_handler
+    history.train_no_handler,
+    train_wifi12306.train_handler,
+    train_wifi12306.train_handler_short
 ]

--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -2,7 +2,7 @@
 # init.py for the commands folder
 # By waymao in 2019
 
-from . import basics, timetable, train_plan_graph, history, train_wifi12306
+from . import basics, timetable, train_plan_graph, history, train_wifi12306, pids_realtime
 
 handlers = [
     basics.start_handler,
@@ -11,5 +11,6 @@ handlers = [
     history.train_info_handler,
     history.train_no_handler,
     train_wifi12306.train_handler,
-    train_wifi12306.train_handler_short
+    train_wifi12306.train_handler_short,
+    pids_realtime.pids_handler
 ]

--- a/commands/pids_realtime.py
+++ b/commands/pids_realtime.py
@@ -1,0 +1,124 @@
+# train_wifi12306.py
+# Used to search for timetable on com.wifi12306 .
+# By AgFlore in 2021 based on waymao's work.
+
+import logging
+from datetime import datetime
+import pytz
+from telegram import ParseMode
+from telegram.ext import CommandHandler
+from railroad_lib import query_wifi12306
+
+# Setting appropiate timezone.
+tz = pytz.timezone('Asia/Shanghai')
+
+def parse_timetable_line(one_train):
+    line = "`%s`" %(one_train.get('trainCode', one_train.get('trainNo', '?')))
+    if 'startStationName' in one_train and 'endStationName' in one_train:
+        line += "`(%s-%s)`" % (one_train['startStationName'], one_train['endStationName'])
+    arrive_time = one_train.get('arriveTime', '-')
+    depart_time = one_train.get('departTime', '-')
+    if arrive_time == depart_time:
+        line += " `%s`" % arrive_time
+    else:
+        line += " `%s/%s`" % (arrive_time, depart_time)
+    line += "\n"
+    return line
+
+def parse_timetable(station_code, date):
+    station_table = query_wifi12306.queryStoptimeByStationCode(station_code, date)
+    if station_table and (station_table[0] != "NO_DATA"):
+        result_str = "Timetable: \n"
+        station_table.sort(key=lambda one_train:one_train.get('departTime'))
+        for one_train in station_table:
+            result_str += parse_timetable_line(one_train)
+        return result_str
+    return ""
+
+def timestamp_to_clock(timestamp):
+    return datetime.fromtimestamp(timestamp/1000, tz=tz)
+
+def parse_screen_line(line, ignore_ok=""):
+    # The timestamp returned. Note that this is not necessarily the timestamp scheduled in the timetable.
+    if line.get('arriveTime'):
+        train_time = timestamp_to_clock(line['arriveTime']).strftime("%H:%M")
+    else:
+        train_time = timestamp_to_clock(line.get('departTime')).strftime("%H:%M")
+    # Parse the train status
+    statuses = {1:'候车', 2:'开检', 3:'停检', 4:'正点', 5:'晚点', 6:'预计晚点', 7:'到站', 8:'停运'}
+    status_code = line.get('status', 0)
+    status_str = statuses.get(status_code, status_code)
+    delay_code = line.get('delay')
+    if delay_code and status_code not in [5, 8]:
+        if isinstance(delay_code, int) and delay_code<0:
+            status_str += " 早%s分" % (-delay_code)
+        else:
+            status_str += " 晚%s分" % (delay_code)
+    elif delay_code and status_code==5:
+        status_str = "晚%s分" % (delay_code)
+    start_end_str = "%s-%s" % (line.get('startStationName'), line.get('endStationName'))
+    # Ignore trivial statuses by request
+    if (not delay_code) and ((ignore_ok, status_code) in [('D', 1), ('A', 4)]):
+        return ""
+    # Line Sample: "D2776 太原南-郑州东　　22:57 [晚247分]"
+    result_str = "%s %s%s [%s]\n" % (
+        line.get('stationTrainCode').ljust(5),
+        start_end_str.ljust(9, '　'),
+        train_time, status_str)
+    return result_str
+
+def parse_screen(station_code, date, flag):
+    flag_parser = {'D':('D','Departures',''), 'd':('D', 'Departures', 'D'), 'A':('A', 'Arrivals', ''), 'a':('A', 'Arrivals','A')}
+    DA_type, da_string, ignore_ok = flag_parser.get(flag)
+    screen = query_wifi12306.getBigScreenByStationCodeAndDate(station_code, date, DA_type)
+
+    if screen and screen[0] != 'NO_DATA':
+        result_str = "<pre>%s at %s (%s)\n\n" % (da_string, screen[0].get('currentStationName'), screen[0].get('currentStationCode'))
+        if ignore_ok:
+            result_str += "(Trains without any non-trivial status have been omitted from the table. They are expected to be running normally.)\n\n"
+        for line in screen:
+            result_str += parse_screen_line(line, ignore_ok)
+            if len(result_str) > 4000:
+                result_str += '(...)'
+                break
+        result_str += "\nUpdated at %s</pre>" % timestamp_to_clock(screen[0].get('updateTime'))
+        return result_str
+    return "No data were returned for your query."
+
+def station_realtime(update, context):
+    # Check valid args:
+    if len(context.args) <= 0:
+        update.message.reply_text(
+            "Usage: /pids <Station Telecode> <A|D|a|d> [Date]\n\nFor a list of station telecodes consult https://kyfw.12306.cn/otn/resources/js/framework/station_name.js\nUse the flags for all [A]rrivals, [D]epartures, or for [a]rrivals/[d]epartures having non-trivial statuses only.",
+            reply_to_message_id=update.message.message_id,)
+        return
+    elif len(context.args) > 3:
+        context.bot.send_message(chat_id=update.message.chat_id,
+            text="Invalid arguments. Usage: /pids <Station Telecode> <A|D|a|d> [Date]",
+            reply_to_message_id=update.message.message_id)
+        return
+    if len(context.args) < 3:
+        date = datetime.now(tz).strftime("%Y%m%d")
+    else:
+        date = query_wifi12306.date_to_integer(context.args[2])
+    if len(context.args) < 2:
+        query_type = 'A'
+    else:
+        query_type = context.args[1]
+
+    # Loading...
+    text = "Please wait while I retrieve the station's realtime PIDS..."
+    msg = context.bot.send_message(chat_id=update.message.chat_id, text=text,
+        reply_to_message_id=update.message.message_id)
+
+    station_code = context.args[0].upper()
+    result_str = parse_screen(station_code, date, query_type)
+
+    # Edit message, replace placeholder
+    context.bot.edit_message_text(chat_id=update.message.chat_id, text=result_str, message_id=msg.message_id, parse_mode=ParseMode.HTML)
+
+    # Logs down each query.
+    logging.info("User %s (id: %s) queryed for the screen of %s by %s on %s.", update.message.from_user.username, update.message.from_user.id, station_code, query_type, date)
+
+# Add handler for the functions.
+pids_handler = CommandHandler('pids', station_realtime, pass_args=True, run_async=True)

--- a/commands/pids_realtime.py
+++ b/commands/pids_realtime.py
@@ -1,5 +1,5 @@
-# train_wifi12306.py
-# Used to search for timetable on com.wifi12306 .
+# pids_realtime.py
+# Used to get station's real-time PIDS board from com.wifi12306
 # By AgFlore in 2021 based on waymao's work.
 
 import logging
@@ -45,9 +45,9 @@ def parse_screen_line(line, ignore_ok=""):
     else:
         train_time = timestamp_to_clock(line.get('departTime')).strftime("%H:%M")
     # Parse the train status
-    statuses = {1:'候车', 2:'开检', 3:'停检', 4:'正点', 5:'晚点', 6:'预计晚点', 7:'到站', 8:'停运'}
+    # statuses = {1:'候车', 2:'开检', 3:'停检', 4:'正点', 5:'晚点', 6:'预计晚点', 7:'到站', 8:'停运'}
     status_code = line.get('status', 0)
-    status_str = statuses.get(status_code, status_code)
+    status_str = query_wifi12306.bigscreen_status_dict.get(status_code, status_code)
     delay_code = line.get('delay')
     if delay_code and status_code not in [5, 8]:
         if isinstance(delay_code, int) and delay_code<0:

--- a/commands/timetable.py
+++ b/commands/timetable.py
@@ -20,15 +20,14 @@ tz = pytz.timezone('Asia/Shanghai')
 
 # function timetable
 # main handler for the command.
-@run_async
 def timetable(update, context):
     # Check valid args:
     if len(context.args) == 0:
         # calendar_func(bot, update)
-        update.message.reply_text(chat_id=update.message.chat_id, 
-            text="Please enter the train no. \
+        update.message.reply_text(text="Please enter the train no. \
                 The calendar function is being developed.",
             reply_to_message_id=update.message.message_id)
+        return
     if len(context.args) == 1:
         date = datetime.now(tz).strftime("%Y-%m-%d")
     elif len(context.args) != 2:
@@ -38,7 +37,7 @@ def timetable(update, context):
         return
     else:
         date = context.args[1]
-    
+
     # Loading...
     text = "Please wait while I retrieve the timetable..."
     msg = context.bot.send_message(chat_id=update.message.chat_id, text=text,
@@ -66,10 +65,10 @@ def timetable(update, context):
                 one_station["arrive_time"],
                 one_station["start_time"]
             )
-        
+
         # Edit message, replace placeholder
         context.bot.edit_message_text(chat_id=update.message.chat_id, text=result_str, message_id=msg.message_id)
-    
+
     # Error Handling.
     # KeyError: somehow 12306 returned something with status code != 200
     except (KeyError, json.JSONDecodeError):
@@ -93,9 +92,9 @@ def timetable(update, context):
             context.bot.edit_message_text(chat_id=update.message.chat_id,
                 text="Sorry. Could not establish a connection to the 12306 server.",
                 message_id=msg.message_id)
-    
+
     # Logs down each query.
     logging.info("User {} (id: {}) searched for train {}".format(update.message.from_user.username, update.message.from_user.id, train))
 
 # Add handler for the functions.
-timetable_handler = CommandHandler('tt', timetable, pass_args=True)
+timetable_handler = CommandHandler('tt', timetable, pass_args=True, run_async=True)

--- a/commands/train_wifi12306.py
+++ b/commands/train_wifi12306.py
@@ -1,0 +1,151 @@
+# train_wifi12306.py
+# Used to search for timetable on com.wifi12306 .
+# By AgFlore in 2021 based on waymao's work.
+
+import logging
+import pytz
+from datetime import datetime
+from telegram.ext import CommandHandler
+from railroad_lib import query_wifi12306
+from telegram import ParseMode
+
+# Setting appropiate timezone.
+tz = pytz.timezone('Asia/Shanghai')
+
+def parse_timetable(train_data):
+    if train_data:
+        result_str = "<pre>"
+
+        station_date = ''
+        for one_station in train_data:
+            if (one_station["trainDate"] != station_date):
+                station_date = one_station["trainDate"]
+                result_str += "   (%s)\n"%(station_date)
+            
+            # Sample line: "08 西安　　0940/0948 1509㎞ Z217 晚750分"
+            delay_status = one_station['ticketDelay']
+            delay_str = one_station["stationTrainCode"]
+            if one_station['ticketDelay']:
+                if delay_status == -1:
+                    delay_str += " 晚点未定"
+                else: 
+                    delay_str += " 晚%s分"%(delay_status)
+
+            result_str += "{} {}{}/{}\t{}㎞\t{}\n".format(
+                one_station["stationNo"],
+                one_station["stationName"].ljust(4, '　'),
+                one_station["arriveTime"],
+                one_station["startTime"],
+                str(one_station['distance']).rjust(4),
+                delay_str
+            )
+        result_str += "</pre>"
+        return result_str
+    return ""
+
+def parse_guide(train_data):
+    if not train_data:
+        return ""
+    guide_payload = ""
+    for one_station in train_data:
+        this_station_info = ""
+        if ("waitingRoom" in one_station) and (one_station["waitingRoom"] != '-'):
+            this_station_info += "[候]%s " % (one_station["waitingRoom"])
+        if ("wicket" in one_station) and (one_station["wicket"] != '-'):
+            this_station_info += "[检]%s " % (one_station["wicket"])
+        if ("exit" in one_station) and (one_station["exit"] != '-'):
+            this_station_info += "[出]%s" % (one_station["exit"])
+        # Print line only when it has content
+        if this_station_info:
+            # Sample line: "(SZH) 苏州 [候]普速东候车区,普速西候车区 [检]5A检票口 [出]南1出站口,南2出站口"
+            guide_payload += "(%s) %s\t%s\n" % (
+                one_station["stationTelecode"], one_station["stationName"], this_station_info)
+    # Print block only if it has content
+    if guide_payload:
+        result_str = "Traveller's Guide:\n%s\n" % (guide_payload)
+        return result_str
+    return ""
+
+
+def parse_compilation(train_no):
+    '''
+    Return sample:
+    Compilation: 
+    01(P1) KD    0    
+    02(P1) YZ    118  
+    03(P1) YZ    118  
+    04(P1) YZ    112 D
+    05(P1) YW    66   
+    '''
+    train_compile = query_wifi12306.getTrainCompileListByTrainNo(train_no)
+    if train_compile and (train_compile[0] != 'NO_DATA'):
+        result_str = "Compilation: \n"
+        for one_train in train_compile:
+            result_str += "{}({}) {}{} {}\n".format(
+                one_train['coachNo'], 
+                one_train['origin'], 
+                one_train['coachType'], 
+                str(one_train['limit1']).ljust(3), 
+                one_train['commentCode'])
+        return result_str
+    return ""
+
+def parse_equipment(train_no):
+    train_equipment = query_wifi12306.getTrainEquipmentByTrainNo(train_no)
+    if train_equipment and (train_equipment[0] != 'NO_DATA'):
+        result_str = "Equipment: \n"
+        result_str += "%s\n"%(train_equipment)
+        return result_str
+    return ""
+
+# main handler for the command.
+def train_wifi(update, context):
+    # Check valid args:
+    if len(context.args) == 0:
+        update.message.reply_text(chat_id=update.message.chat_id, 
+            text="Please enter the train no. \
+                The calendar function is being developed.",
+            reply_to_message_id=update.message.message_id)
+    if len(context.args) == 1:
+        date = datetime.now(tz).strftime("%Y%m%d")
+    elif len(context.args) != 2:
+        context.bot.send_message(chat_id=update.message.chat_id,
+            text="Invalid arguments. Usage: /train <Train Number>",
+            reply_to_message_id=update.message.message_id)
+        return
+    else:
+        # Because some trains are not accessible by "yyyy-mm-dd"; only "yyyymmdd" gets response
+        date = context.args[1].replace('-', '')
+        
+    # Loading...
+    text = "Please wait while I retrieve the timetable..."
+    msg = context.bot.send_message(chat_id=update.message.chat_id, text=text,
+        reply_to_message_id=update.message.message_id)
+
+    train_code = context.args[0]
+    train_data = query_wifi12306.getStoptimeByTrainCode(train_code, date)
+    if train_data[0] != 'NO_DATA':
+        result_str = parse_timetable(train_data)
+        result_str += "\n<pre>%s</pre><pre>%s (%s - %s)\n%s</pre>\n<pre>%s</pre>"%(
+            parse_guide(train_data),
+            train_data[0]["trainNo"], 
+            train_data[0]['startDate'], 
+            train_data[0]['stopDate'], 
+            parse_compilation(train_data[0]["trainNo"]),
+            parse_equipment(train_data[0]["trainNo"]))
+
+        # Edit message, replace placeholder
+        context.bot.edit_message_text(chat_id=update.message.chat_id, text=result_str, message_id=msg.message_id, parse_mode=ParseMode.HTML)
+    
+    # Error Handling.
+    else:
+        context.bot.edit_message_text(chat_id=update.message.chat_id,
+            text=train_data[1],
+            message_id=msg.message_id)
+    
+    # Logs down each query.
+    logging.info("User %s (id: %s) searched for %s on %s", update.message.from_user.username, update.message.from_user.id, train_code, date)
+
+# Add handler for the functions.
+train_handler = CommandHandler('train', train_wifi, pass_args=True, run_async=True)
+train_handler_short = CommandHandler('tw', train_wifi, pass_args=True, run_async=True)

--- a/commands/train_wifi12306.py
+++ b/commands/train_wifi12306.py
@@ -83,12 +83,14 @@ def parse_compilation(train_no):
     if train_compile and (train_compile[0] != 'NO_DATA'):
         result_str = "Compilation: \n"
         for one_train in train_compile:
+            comment = one_train.get('commentCode')
+            comment_str = query_wifi12306.compile_comment_dict.get(comment, comment)
             result_str += "{}({}) {}{} {}\n".format(
                 one_train.get('coachNo'),
                 one_train.get('origin'),
                 one_train.get('coachType'),
                 str(one_train.get('limit1')).ljust(3),
-                one_train.get('commentCode'))
+                comment_str)
         return result_str
     return ""
 

--- a/railroad_lib/query_wifi12306.py
+++ b/railroad_lib/query_wifi12306.py
@@ -1,0 +1,134 @@
+# query_wifi12306.py
+# looks for timetable on com.wifi12306.
+# Modified by AgFlore from lfz's version
+
+import requests
+import json
+
+header = {
+    'Host': 'wifi.12306.cn',
+    'Connection': 'keep-alive',
+    'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36 MicroMessenger/7.0.9.501 NetType/WIFI MiniProgramEnv/Windows WindowsWechat',
+    'appName': 'zhongtiexing',
+    'appVer': '5.1.0',
+    'accessToken': '',
+    'Referer': 'https://servicewechat.com/wx4e4bb9a3f684dd0a/112/page-frame.html',
+    'Accept-Encoding': 'gzip, deflate, br'
+}
+
+def json_parser(rawData):
+    data={}
+    try:
+        data = json.loads(rawData)['data']
+    except:
+        return ['NO_DATA', rawData]
+    return data
+
+
+def getTrainListFromToStationName(queryDate,fromStationName,toStationName) -> list:
+    response = requests.get("https://wifi.12306.cn/wifiapps/ticket/api/stoptime/queryByStationName?fromStationName=%s&toStationName=%s&trainDate=%s "%(fromStationName,toStationName,queryDate), headers=header)
+    return json_parser(response.content.decode('utf-8'))
+
+def queryTrainTicketPriceList(startStationCode, endStationCode, trainDate, ticketType=1) -> list:
+    '''
+        queryTrainTicketPriceList('BJP', 'VIH', '2021-10-01') returns
+        [{'trainNo': '24000K16130C', 'softSeat': '--', 'hardBerth': '02150', 'motorCarBerth': '--', 'softBerth': '03360', 'firstBreth': '--', 'secondBreth': '--', 'firstClassSeats': '--', 'secondClassSeat': '--', 'highGradeSoftBerth': '--', 'businessAndSpecialSeat': '--', 'noSeat': '01240', 'hardSeat': '01240', 'distance': 942, 'fromStationTelecode': 'BJP', 'toStationTelecode': 'VIH'}, {'trainNo': '24000G258710', 'softSeat': '--', 'hardBerth': '--', 'motorCarBerth': '--', 'softBerth': '--', 'firstBreth': '--', 'secondBreth': '--', 'firstClassSeats': '--', 'secondClassSeat': '--', 'highGradeSoftBerth': '--', 'businessAndSpecialSeat': '--', 'noSeat': '--', 'hardSeat': '--', 'distance': 792, 'fromStationTelecode': 'VNP', 'toStationTelecode': 'XYU'}]
+    '''
+    response = requests.get("https://wifi.12306.cn/wifiapps/ticket/api/trainTicketList/queryTrainTicketPriceList?startStationCode=%s&endStationCode=%s&trainDate=%s&ticketType=%s"%(startStationCode, endStationCode, trainDate, ticketType), headers=header)
+    return json_parser(response.content.decode('utf-8'))
+
+def getFuxingTrain():
+    response = requests.get("https://wifi.12306.cn/wifiapps/ticket/api/trainType/getRevivalTrain", headers=header)
+    return json_parser(response.content.decode('utf-8'))
+
+
+def getStoptimeByStationName(fromStationName, toStationName, trainDate) -> list:
+    response = requests.get("https://wifi.12306.cn/wifiapps/ticket/api/stoptime/queryByStationName?fromStationName=%s&toStationName=%s&trainDate=%s"%(fromStationName, toStationName, trainDate), headers=header)
+    return json_parser(response.content.decode('utf-8'))
+
+def getStoptimeByTrainCode(trainCode, trainDate, getBigScreen='YES') -> list:
+    '''
+    Note: some trains can only be retrieved from '20211011'. Query with '2021-10-11' returns nothing.
+    '''
+    response = requests.get("https://wifi.12306.cn/wifiapps/ticket/api/stoptime/queryByTrainCode?trainCode=%s&trainDate=%s&getBigScreen=%s"%(trainCode, trainDate, getBigScreen), headers=header)
+    return json_parser(response.content.decode('utf-8'))
+
+def queryStoptimeByStationCode(stationCode, trainDate):
+    response = requests.get("https://wifi.12306.cn/wifiapps/ticket/api/stoptime/queryByStationCodeAndDate?stationCode=%s&trainDate=%s"%(stationCode, trainDate), headers=header)
+    return json_parser(response.content.decode('utf-8'))
+
+def getRunRuleByTrainNoAndDateRange(trainNo, start, end):
+    response = requests.get("https://wifi.12306.cn/wifiapps/ticket/api/trainDetailInfo/queryTrainRunRuleByTrainNoAndDateRange?trainNo=%s&start=%s&end=%s"%(trainNo, start, end), headers=header)
+    return json_parser(response.content.decode('utf-8'))
+
+def getTrainEquipmentByTrainNo(trainNo) -> list:
+    '''
+    Sample: [{'eId': 157047494, 'bureaName': '京', 'trainsetType': 'CRH6F-A', 'trainsetName': 'CRH6F-A-0494', 'deploydepotName': '京动', 'depotName': '北京北所', 'trainsetStatus': '载客运行', 'date': '2021-10-03'}]
+    Only matches the current trainCode from trainNo, and returns the current status; will answer to even non-existent trainNo like '24000000G199'.
+    '''
+    response = requests.get("https://wifi.12306.cn/wifiapps/ticket/api/trainDetailInfo/queryTrainEquipmentByTrainNo?trainNo=%s"%trainNo, headers=header)
+    return json_parser(response.content.decode('utf-8'))
+
+def getTrainCompileListByTrainNo(trainNo) -> list:
+    '''
+        queryTrainCompileListByTrainNo('800000D9300A') returns 
+        [{'startDate': '20190105', 'trainNo': '800000D9300A', 'coachNo': '01', 'stopDate': '20401231', 'coachType': 'RW    ', 'limit1': 40, 'limit2': 0, 'commentCode': ' ', 'trainGroupNo': 0, 'origin': 'M1', 'runningStyle': 1, 'runningRule': 1, 'seatFeature': '3'}, {'startDate': '20190105', 'trainNo': '800000D9300A', 'coachNo': '02', 'stopDate': '20401231', 'coachType': 'RW    ', 'limit1': 60, 'limit2': 0, 'commentCode': ' ', 'trainGroupNo': 0, 'origin': 'M1', 'runningStyle': 1, 'runningRule': 1, 'seatFeature': '3'}, ...]
+    '''
+    response = requests.get("https://wifi.12306.cn/wifiapps/ticket/api/trainDetailInfo/queryTrainCompileListByTrainNo?trainNo=%s"%trainNo, headers=header)
+    return json_parser(response.content.decode('utf-8'))
+
+def queryPreseqTrainsByTrainCode(trainCode):
+    '''
+        Usage Unknown
+    '''
+    response = requests.get("https://wifi.12306.cn/wifiapps/ticket/api/trainDetailInfo/queryPreseqTrainsByTrainCode?trainCode=%s"%trainCode, headers=header)
+    return json_parser(response.content.decode('utf-8'))
+
+def getTrainsetTypeByTrainCode(trainCode):
+    response = requests.get("https://wifi.12306.cn/wifiapps/ticket/api/trainDetailInfo/getTrainsetTypeByTrainCode?trainCode=%s"%trainCode, headers=header)
+    return json_parser(response.content.decode('utf-8'))
+
+def getBigScreenByLocation(latitude, longitude, DA_type='D'):
+    response = requests.get("https://wifi.12306.cn/wifiapps/appFrontEnd/v2/kpBigScreen/getBigScreenByLocation?latitude=%s&longitude=%s&type=%s"%(latitude, longitude, DA_type), headers=header)
+    return json_parser(response.content.decode('utf-8'))
+
+def getBigScreenByStationCodeAndDate(stationCode, queryDate, DA_type='A') -> list:
+    '''
+    status: 1=正在候车, 2=正在检票, 3=停检, 4=正点, 5=晚点, 8=停运
+    '''
+    response = requests.get("https://wifi.12306.cn/wifiapps/appFrontEnd/v2/kpBigScreen/getBigScreenByStationCodeAndTrainDate?stationCode=%s&trainDate=%s&type=%s"%(stationCode, queryDate, DA_type), headers=header)
+    return json_parser(response.content.decode('utf-8'))
+
+def test_module(label, response, answer):
+    if (response==answer):
+        print("Module %s: Test OK."%label)
+    else:
+        print("Module %s returns %s"%(label, response))
+
+if __name__ == '__main__':
+    test_module("getTrainListFromToStationName", getTrainListFromToStationName('202110-01','北京','奇峰塔'), [{'fromStationCode': 'BXP', 'fromStationName': '北京西', 'fromStationDate': '202110-01 ', 'fromStationArriveTime': '1745', 'fromStationDepartTime': '1745', 'fromStationArriveDateTime': 1633039500000, 'fromStationDepartDateTime': 1633039500000, 'fromStationNo': '01', 'fromTrainCode': '6437', 'isStartStation': True, 'fromStationDistance': 0, 'toStationCode': 'QVP', 'toStationName': '奇峰塔', 'toStationArriveTime': '2143', 'toStationDepartTime': '2145', 'toStationDate': '202110-01 ', 'toStationArriveDateTime': 1633063380000, 'toStationDepartDateTime': 1633063500000, 'toStationNo': '18', 'toTrainCode': '6437', 'trainNo': '24000064370K', 'isEndStation': False, 'toStationDistance': 149, 'dayDifference': 0, 'travelDistance': 149, 'travelTimeSpan': 23880000}])
+    
+    test_module("getStoptimeByStationName", getStoptimeByStationName('深圳', '苏州', '20211003'), [{'fromStationCode': 'IOQ', 'fromStationName': '深圳北', 'fromStationDate': '20211003', 'fromStationArriveTime': '0950', 'fromStationDepartTime': '0950', 'fromStationArriveDateTime': 1633225800000, 'fromStationDepartDateTime': 1633225800000, 'fromStationNo': '01', 'fromTrainCode': 'D2282', 'isStartStation': True, 'fromStationDistance': 0, 'toStationCode': 'SZH', 'toStationName': '苏州', 'toStationArriveTime': '2153', 'toStationDepartTime': '2155', 'toStationDate': '20211003', 'toStationArriveDateTime': 1633269180000, 'toStationDepartDateTime': 1633269300000, 'toStationNo': '28', 'toTrainCode': 'D2282', 'trainNo': '6i000D22820F', 'isEndStation': False, 'toStationDistance': 1707, 'dayDifference': 0, 'travelDistance': 1707, 'travelTimeSpan': 43380000, 'controlledTrainFlag': '0', 'controlledTrainMessage': '正常车次，不受控'}, {'fromStationCode': 'SZQ', 'fromStationName': '深圳', 'fromStationDate': '20211003', 'fromStationArriveTime': '1206', 'fromStationDepartTime': '1206', 'fromStationArriveDateTime': 1633233960000, 'fromStationDepartDateTime': 1633233960000, 'fromStationNo': '01', 'fromTrainCode': 'K34', 'isStartStation': True, 'fromStationDistance': 0, 'toStationCode': 'SZH', 'toStationName': '苏州', 'toStationArriveTime': '1152', 'toStationDepartTime': '1152', 'toStationDate': '20211004', 'toStationArriveDateTime': 1633319520000, 'toStationDepartDateTime': 1633319520000, 'toStationNo': '15', 'toTrainCode': 'K35', 'trainNo': '6500000K3409', 'isEndStation': True, 'toStationDistance': 1725, 'dayDifference': 1, 'travelDistance': 1725, 'travelTimeSpan': 85560000, 'controlledTrainFlag': '0', 'controlledTrainMessage': '正常车次，不受控'}])
+
+    test_module("getStoptimeByTrainCode", getStoptimeByTrainCode('Z29', '2021-09-30'), [{'trainDate': '2021-09-30', 'startDate': '20201012', 'stopDate': '20210119', 'trainNo': '2400000Z290F', 'stationNo': '01', 'stationName': '北京', 'bureauCode': 'P', 'stationTelecode': 'BJP', 'stationTrainCode': 'Z29', 'dayDifference': 0, 'arriveTime': '2133', 'arriveTimestamp': 1607560380000, 'startTime': '2133', 'startTimestamp': 1607560380000, 'ticketDelay': 0, 'waitingRoom': '-', 'wicket': '-', 'distance': 0, 'timeSpan': 0, 'oneStationCrossDay': False}, {'trainDate': '20201210', 'startDate': '20201012', 'stopDate': '20210119', 'trainNo': '2400000Z290F', 'stationNo': '02', 'stationName': '扬州', 'bureauCode': 'H', 'stationTelecode': 'YLH', 'stationTrainCode': 'Z29', 'dayDifference': 1, 'arriveTime': '0800', 'arriveTimestamp': 1607558400000, 'startTime': '0800', 'startTimestamp': 1607558400000, 'ticketDelay': 0, 'waitingRoom': '-', 'wicket': '-', 'distance': 1228, 'timeSpan': 37620000, 'oneStationCrossDay': False}])
+
+    test_module("queryStoptimeByStationCode", queryStoptimeByStationCode('XPH', '2021-09-15'), [{'trainNo': '5l000G711070', 'trainCode': 'G7110', 'stationName': '仙林', 'stationCode': 'XPH', 'arriveTime': '1444', 'departTime': '1449'}, {'trainNo': '54000G704571', 'trainCode': 'G7045', 'stationName': '仙林', 'stationCode': 'XPH', 'arriveTime': '0938', 'departTime': '0940'}])
+
+    test_module("getRunRuleByTrainNoAndDateRange", getRunRuleByTrainNoAndDateRange('6i0000D9280P',20210919,20210922), {'20210921': '1', '20210920': '0', '20210922': '0', '20210919': '0'})
+
+    test_module("getTrainEquipmentByTrainNo", getTrainEquipmentByTrainNo('800000D9300A'), {})
+    # Should be like [{'eId': 156773881, 'bureaName': '京', 'trainsetType': 'CRH2E', 'trainsetName': 'CRH2E-2464', 'deploydepotName': '京动', 'depotName': '北京南所', 'trainsetStatus': '载客运行', 'date': '2021-10-01'}]
+
+    test_module("getTrainCompileListByTrainNo", getTrainCompileListByTrainNo("240000S50108"), [{'startDate': '20210120', 'trainNo': '240000S50108', 'coachNo': '01', 'stopDate': '20501231', 'coachType': 'RZ2   ', 'limit1': 48, 'limit2': 0, 'commentCode': ' ', 'trainGroupNo': 0, 'origin': 'PM', 'runningStyle': 1, 'runningRule': 1, 'seatFeature': '3'}, {'startDate': '20210120', 'trainNo': '240000S50108', 'coachNo': '02', 'stopDate': '20501231', 'coachType': 'RZ2   ', 'limit1': 56, 'limit2': 0, 'commentCode': ' ', 'trainGroupNo': 0, 'origin': 'PM', 'runningStyle': 1, 'runningRule': 1, 'seatFeature': '3'}, {'startDate': '20210120', 'trainNo': '240000S50108', 'coachNo': '03', 'stopDate': '20501231', 'coachType': 'RZ2   ', 'limit1': 56, 'limit2': 0, 'commentCode': ' ', 'trainGroupNo': 0, 'origin': 'PM', 'runningStyle': 1, 'runningRule': 1, 'seatFeature': '3'}, {'startDate': '20210120', 'trainNo': '240000S50108', 'coachNo': '04', 'stopDate': '20501231', 'coachType': 'RZ2   ', 'limit1': 40, 'limit2': 0, 'commentCode': ' ', 'trainGroupNo': 0, 'origin': 'PM', 'runningStyle': 1, 'runningRule': 1, 'seatFeature': '3'}])
+
+    test_module("getTrainsetTypeByTrainCode", getTrainsetTypeByTrainCode("C2201"), {'trainsetTypeName': 'CR400BF', 'trainsetType': '复兴号', 'trainsetTypeImgUrl': 'https://eximages.12306.cn/wificloud/wifiapps/trainbodypic/CR.png', 'trainsetTypeAllImgUrl': 'https://eximages.12306.cn/wificloud/wifiapps/trainbodypic/CR400short-all.png', 'networkType': 'Wi-Fi', 'mealCoach': '05车', 'maxSpeed': '420km/h', 'currentSpeed': '350km/h', 'coachCount': '8', 'capacity': '576人', 'fullLength': '209.06m', 'coachOrganization': '4节动车,4节拖车', 'first': [{'coachNo': '01', 'seatType': '一等/商务座', 'capacity': '33人', 'coachImageUrl': 'https://eximages.12306.cn/wificloud/wifiapps/trainbodypic/CR400short-01(09).png', 'powerType': '拖车(控制车)'}, {'coachNo': '02', 'seatType': '二等座', 'capacity': '90人', 'coachImageUrl': 'https://eximages.12306.cn/wificloud/wifiapps/trainbodypic/CR400short-02-03-06-07(10-11-14-15).png', 'powerType': '动车'}, {'coachNo': '03', 'seatType': '二等座', 'capacity': '90人', 'coachImageUrl': 'https://eximages.12306.cn/wificloud/wifiapps/trainbodypic/CR400short-02-03-06-07(10-11-14-15).png', 'powerType': '拖车(受电弓)'}, {'coachNo': '04', 'seatType': '二等座', 'capacity': '75人', 'coachImageUrl': 'https://eximages.12306.cn/wificloud/wifiapps/trainbodypic/CR400short-04(12).png', 'powerType': '动车'}, {'coachNo': '05', 'seatType': '二等/餐车', 'capacity': '63人', 'coachImageUrl': 'https://eximages.12306.cn/wificloud/wifiapps/trainbodypic/CR400short-05(13).png', 'powerType': '动车'}, {'coachNo': '06', 'seatType': '二等座', 'capacity': '90人', 'coachImageUrl': 'https://eximages.12306.cn/wificloud/wifiapps/trainbodypic/CR400short-02-03-06-07(10-11-14-15).png', 'powerType': '拖车(受电弓)'}, {'coachNo': '07', 'seatType': '二等座', 'capacity': '90人', 'coachImageUrl': 'https://eximages.12306.cn/wificloud/wifiapps/trainbodypic/CR400short-02-03-06-07(10-11-14-15).png', 'powerType': '动车'}, {'coachNo': '08', 'seatType': '二等/商务座', 'capacity': '45人', 'coachImageUrl': 'https://eximages.12306.cn/wificloud/wifiapps/trainbodypic/CR400short-08(16).png', 'powerType': '拖车(控制车)'}], 'manufacturer': '中车唐山机车车辆有限公司,中车长春轨道客车股份有限公司', 'indexKey': 'CR400BF'})
+
+    test_module("queryStoptimeByStationCode", queryStoptimeByStationCode('AFP', '2019-05-05'), [{'trainNo': '24000064380F', 'trainCode': '6438', 'stationName': '云居寺', 'stationCode': 'AFP', 'startStationName': '大涧', 'startStationCode': 'DFP', 'endStationName': '北京西', 'endStationCode': 'BXP', 'arriveTime': '1024', 'departTime': '1026'}, {'trainNo': '24000064370I', 'trainCode': '6437', 'stationName': '云居寺', 'stationCode': 'AFP', 'arriveTime': '1937', 'departTime': '1939'}])
+
+    import datetime
+
+    test_module('queryTrainTicketPriceList', queryTrainTicketPriceList('BJP', 'SEP', datetime.date.today()), '1')
+
+    test_module("getBigScreenByStationCodeAndDate", getBigScreenByStationCodeAndDate('NEH', datetime.datetime.now().strftime('%Y%m%d'), 'A'), '0')
+
+    test_module("queryPreseqTrainsByTrainCode", queryPreseqTrainsByTrainCode('G21'), '0')

--- a/railroad_lib/query_wifi12306.py
+++ b/railroad_lib/query_wifi12306.py
@@ -2,8 +2,8 @@
 # looks for timetable on com.wifi12306.
 # Modified by AgFlore from lfz's version
 
-import requests
 import json
+import requests
 import dateutil.parser
 
 header = {
@@ -62,8 +62,7 @@ def getStoptimeByTrainCode(trainCode, trainDate, getBigScreen='YES') -> list:
 def queryStoptimeByStationCode(stationCode, trainDate):
     '''
     Note: Use 'yyyymmdd' only. Query with 'yyyy-mm-dd' could return expired data.
-    Only data after 2021-01-20 have infomation about trains' start/end stations.
-    Before 2021-01-19, data
+    Only data after 2021-01-20 include infomation about trains' start/end stations.
     '''
     response = requests.get("https://wifi.12306.cn/wifiapps/ticket/api/stoptime/queryByStationCodeAndDate?stationCode=%s&trainDate=%s"%(stationCode, trainDate), headers=header)
     return json_parser(response.content.decode('utf-8'))
@@ -88,6 +87,45 @@ def getTrainCompileListByTrainNo(trainNo) -> list:
     response = requests.get("https://wifi.12306.cn/wifiapps/ticket/api/trainDetailInfo/queryTrainCompileListByTrainNo?trainNo=%s"%trainNo, headers=header)
     return json_parser(response.content.decode('utf-8'))
 
+# For interpreting the "commentCode"
+# TBA:
+# 'E' appeared once in 26000K77520E (YW25G, capacity=66)
+# 'J' appeared once in 12000K12270V (YZ25G, capacity=108)
+compile_comment_dict = {
+    'B': '㊙️宿营车',
+    'C': '🎙️带广播室',
+    'D': '👮‍♀️带列车长办公席',
+    'H': '➡️联运出境',
+    'I': '↩️回转',
+    'L': '❌欠编',
+    'N': '♿️无障碍',
+    'O': '🎙️♿️无障碍+广播室',
+    'P': '👮‍♀️♿️无障碍+列车长办公席',
+    'Q': '🤫静音车厢'
+}
+# For interpreting the "origin". First digit is bureau, second digit represents 直通/管内.
+bureau_dict = {
+    'B': '哈局',
+    'C': '呼局',
+    'D': '锦局', 'L': '吉局', 'T': '沈局',
+    'F': '郑局',
+    'G': '南局', 'S': '福局',
+    'H': '上局', 'U': '新上局',
+    'J': '兰局',
+    'K': '济局', 'I': '济局',
+    'M': '昆局',
+    'N': '武局',
+    'O': '青藏',
+    'P': '京局',
+    'Q': '广铁', 'A': '新广铁',
+    'R': '乌局',
+    'V': '太局',
+    'W': '成局', 'E': '新成局',
+    'X': '境外',
+    'Y': '西局',
+    'Z': '宁局'
+}
+
 def queryPreseqTrainsByTrainCode(trainCode):
     '''
         Usage Unknown
@@ -110,6 +148,9 @@ def getBigScreenByStationCodeAndDate(stationCode, queryDate, DA_type='A') -> lis
     '''
     response = requests.get("https://wifi.12306.cn/wifiapps/appFrontEnd/v2/kpBigScreen/getBigScreenByStationCodeAndTrainDate?stationCode=%s&trainDate=%s&type=%s"%(stationCode, queryDate, DA_type), headers=header)
     return json_parser(response.content.decode('utf-8'))
+
+# For interpreting "status"
+bigscreen_status_dict = {1:'候车', 2:'开检', 3:'停检', 4:'正点', 5:'晚点', 6:'预计晚点', 7:'到站', 8:'停运'}
 
 def test_module(label, response, answer):
     if (response==answer):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests
 pymysql
 prettytable
 pytz
+python-dateutil


### PR DESCRIPTION
Sample response for `/train Z257 2021-10-07`:
```
   (20211007)
01 上海南　1909/1909    0㎞ Z257
02 嘉兴　　1955/1959   80㎞ Z257
03 杭州南　2107/2113  188㎞ Z257
04 义乌　　2156/2200  312㎞ Z257 晚11分
05 金华　　2231/2237  360㎞ Z257 晚12分
   (20211008)
06 武昌　　0440/0503 1032㎞ Z256
07 宜昌东　0723/0732 1337㎞ Z257
08 恩施　　0931/0937 1551㎞ Z257 晚35分
09 重庆北　1249/1249 1890㎞ Z257 晚12分

Traveller's Guide:
(SNH) 上海南 [检]8候车区 
(JXH) 嘉兴 [检]1（南） 
(XHH) 杭州南 [检]8A 
(YWH) 义乌 [候]2号候车室 [检]2号A检票口 [出]出口处
(JBH) 金华 [检]普速 [出]出口处,南出口处
(WCN) 武昌 [出]东出站口,西出站口
(HAN) 宜昌东 [候]二层候车室 [检]二层2检 
(ESN) 恩施 [候]第5候车区,贵宾候车室 [检]检票口2 [出]一层出站口
(CUW) 重庆北 [出]出站口

550000Z25722 (20210625 - 20300303)
Compilation: 
01(H1) YW    0   ️㊙️宿营车
02(H1) YW    66   
03(H1) YW    66   
04(H1) YW    66   
05(H1) YW    66   
06(H1) YW    66   
07(H1) YW    66   
08(H1) CA    0    
09(H1) RW    36   
10(H1) RW    36   
11(H1) YW    57  🎙️带广播室
12(H1) YW    57  ️♿️无障碍
13(H1) YW    66   
14(H1) YW    66   
15(H1) YW    66   
16(H1) YW    66   
17(H1) YW    66   
18(H1) YW    66
```

Sample response for `/pids XAY d 2021-10-08`:

```
Departures at 西安 (XAY)

(Trains without any non-trivial status have been omitted from the table. They are expected to be running normally.)

K367  西安-敦煌　　　　15:36 [晚200分]
K5466 西安-安康　　　　15:39 [停运]
K545  哈尔滨-成都　　　15:45 [晚560分]
7008  西安-商南　　　　15:45 [晚29分]
D5296 西安-铜川东　　　15:50 [晚60分]
K8168 宝鸡-榆林　　　　16:02 [晚100分]
D5094 西安-神木　　　　17:00 [晚88分]
D5286 西安-延安　　　　17:30 [晚235分]
K5443 榆林-咸阳　　　　17:53 [晚180分]

Updated at 2021-10-08 15:30:02+08:00
```